### PR TITLE
Increase image upload size and supported formats

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,9 +39,11 @@ class InputValidator {
 
     static validateFile(file) {
         if (!file) return true; // File is optional
-        const maxSize = 5 * 1024 * 1024; // 5MB
-        const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
-        return file.size <= maxSize && allowedTypes.includes(file.type);
+        const maxSize = 10 * 1024 * 1024; // 10MB
+        const isImageType = typeof file.type === 'string' && file.type.startsWith('image/');
+        const hasImageExtension = typeof file.name === 'string'
+            && /\.(apng|avif|bmp|gif|heic|heif|ico|jfif|jpg|jpeg|png|svg|tif|tiff|webp)$/i.test(file.name);
+        return file.size <= maxSize && (isImageType || hasImageExtension);
     }
 }
 


### PR DESCRIPTION
## Summary
- raise the maximum allowed upload size for images to 10 MB
- accept any detected image MIME type and common image file extensions instead of a fixed allowlist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef589337788329a06230b3c5f0d24e