### PR TITLE
Guard Lucide icon initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,22 +391,27 @@
                     this.setTheme(newTheme);
                 });
             }
+            static createIconsSafe() {
+                if (window.lucide && typeof window.lucide.createIcons === 'function') {
+                    window.lucide.createIcons();
+                }
+            }
             static setTheme(theme) {
                 document.documentElement.setAttribute('data-theme', theme);
                 localStorage.setItem('theme', theme);
                 const themeIcon = document.querySelector('.theme-icon');
                 if(themeIcon) {
                     themeIcon.setAttribute('data-lucide', theme === 'light' ? 'moon' : 'sun');
-                    lucide.createIcons();
+                    this.createIconsSafe();
                 }
             }
         }
-        
+
         window.selectedPhotoBase64 = null;
         let typeChartInstance = null;
 
         document.addEventListener('DOMContentLoaded', () => {
-            lucide.createIcons();
+            ThemeManager.createIconsSafe();
             ThemeManager.init();
             migrateLegacyUnloadingTypes();
 
@@ -570,7 +575,7 @@
 
             setupLocationOptions(locations);
             updateTotalAmount();
-            lucide.createIcons();
+            ThemeManager.createIconsSafe();
         }
         
         function populateDatalist() {
@@ -900,7 +905,7 @@
                 empty.style.display = 'block';
                 summary.textContent = 'Ще немає записів';
             }
-            lucide.createIcons();
+            ThemeManager.createIconsSafe();
         }
 
         function deleteItem(id) {


### PR DESCRIPTION
## Summary
- ensure Lucide icons are only rendered when the global library is available
- reuse a shared helper to safely refresh icons during theme and list updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb706d7ee08329a59320ea81cbe163